### PR TITLE
[ FIXED ] Error while running the export test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,11 @@ run: all
 	@clear
 	@./$(NAME)
 
+
+# Descomment the line to get leaks
+VALGRIND_FLAGS=#--leak-check=full
 valgrind: all
 	@clear
-	@./$(NAME)
+	@valgrind $(VALGRIND_FLAGS) ./$(NAME)
 
 .PHONY: all clean fclean re

--- a/Makefile
+++ b/Makefile
@@ -28,20 +28,20 @@ $(LIBFT):
 	@echo "$(GREEN)libft compiled!$(CLEAR)"
 
 clean:
-	@rm -f $(OBJ)
+	@rm -rf $(OBJ)
 	@$(MAKE) clean -C $(LIBFT_DIR)
 	@echo "$(RED)minishell objects removed!$(CLEAR)"
 
 fclean: clean
-	@rm -f $(NAME)
+	@rm -rf $(NAME)
 	@$(MAKE) fclean -C $(LIBFT_DIR)
 	@echo "$(RED)minishell removed!$(CLEAR)"
-	@rm Historial
+	@rm -rf Historial
 
 re: fclean $(NAME)
 
 run: all
-	clear
-	./$(NAME)
+	@clear
+	@./$(NAME)
 
 .PHONY: all clean fclean re

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,8 @@ run: all
 	@clear
 	@./$(NAME)
 
+valgrind: all
+	@clear
+	@./$(NAME)
+
 .PHONY: all clean fclean re

--- a/src/builtins/builtins.c
+++ b/src/builtins/builtins.c
@@ -3,7 +3,7 @@
 void	ft_builtins(t_msh *commands)
 {
 	int i;
-	char *ptr[] = {"DAVID=123", "DAVID=1234", NULL};
+	char *ptr[] = {ft_strdup("DAVID=123"), ft_strdup("DAVID=1234"), ft_strdup("lpastor=old"), ft_strdup("lpastor=new"), ft_strdup("DAVID=ldiaz-ra"), NULL};
 
 	i = 0;
 

--- a/src/builtins/export_manage.c
+++ b/src/builtins/export_manage.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   export_manage.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: david <david@student.42.fr>                +#+  +:+       +#+        */
+/*   By: lpastor- <lpastor-@student.42madrid.com>   +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/13 12:08:39 by david             #+#    #+#             */
-/*   Updated: 2024/04/13 15:41:56 by david            ###   ########.fr       */
+/*   Updated: 2024/04/13 18:48:01 by lpastor-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ void	manage_export(t_msh *commands, int num_command)
 			if (!var_split)
 				exit(1);
 			ft_check_syntax(var_split[0]);
-			update_env(commands, ft_search_env(commands->envp, var_split[0]), commands->cmds[num_command]->args[i]);
+			update_env(commands, ft_search_env(commands->envp, var_split[0]), ft_strdup(commands->cmds[num_command]->args[i]));
 			ft_free_matrix(var_split);
 		}
 		i++;


### PR DESCRIPTION
- Makefile: Added a valgrind rule (with a variable to add flags) and the '-r' flag on the 'rm' commands, to avoid problems if the file dont exist
- src/builtins/builtins.c: Fixed the tests that is created, and added more cases
- src/builtins/export_manage.c: Called the func 'ft_strdup' to create a new variable which can be added to the env. So, there is no problem if it is freed if it is going to be replaced, or when the parser memory is freed after the execution (if you do it)